### PR TITLE
noreferrer implies noopener

### DIFF
--- a/pages/holder.js
+++ b/pages/holder.js
@@ -4,7 +4,7 @@ import Stepper from "../components/Stepper";
 const HolderSection = () => {
   return (
     <section className="mt-2">
-      <a className="relative block h-[125px] md:h-[150px] mx-auto" href="https://discord.gg/7bwXQU77bC" target="_blank" rel="noopener">
+      <a className="relative block h-[125px] md:h-[150px] mx-auto" href="https://discord.gg/7bwXQU77bC" target="_blank" rel="noreferrer">
         <Image
           fill
           unoptimized


### PR DESCRIPTION
Mixed up `noreferrer` and `noopener` on `rel`.  `noreferrer` implies the latter,