### PR TITLE
fix: image generation speed

### DIFF
--- a/components/NFTSelector/Grid.tsx
+++ b/components/NFTSelector/Grid.tsx
@@ -34,7 +34,7 @@ export const Grid: React.FC<GridProps> = ({
       const nextImageSrc = source384.slice(0, source384.lastIndexOf(" "));
       handleSelect({
         ...item,
-        image: `${window.location.origin || ""}${nextImageSrc}`,
+        nextURL: `${window.location.origin || ""}${nextImageSrc}`,
       });
     }
   };

--- a/components/NFTSelector/Grid.tsx
+++ b/components/NFTSelector/Grid.tsx
@@ -1,6 +1,7 @@
-import React from "react";
 import Image from "next/image";
-import type { GridProps } from "./types";
+import React from "react";
+
+import type { GridProps, Item } from "./types";
 
 export const Grid: React.FC<GridProps> = ({
   items,
@@ -9,11 +10,40 @@ export const Grid: React.FC<GridProps> = ({
   selected,
   collectionName,
 }) => {
+  const handleClick = (
+    target: HTMLElement,
+    item: Item,
+    isSelected: boolean
+  ) => {
+    if (isSelected) {
+      handleRemove(item);
+    } else {
+      /**
+       * This needs some explanation.
+       * The free Vercel Hobby plan has execution time of 10s for Next.js API Routes
+       * If we pass the URLs of the full res NFTs to the server,
+       * it takes too much time to download and resize them.
+       * So we are instead passing the Next.js generated 384w version of the NFT image,
+       * extracting that url from the srcset of the related next/image component
+       * DO NOT TRY THIS AT HOME, KIDS :D
+       */
+      const siblingImageElement = target.previousElementSibling;
+      const srcset = siblingImageElement.getAttribute("srcset");
+      const sources = srcset.split(", ");
+      const source384 = sources.find((source) => source.endsWith("384w"));
+      const nextImageSrc = source384.slice(0, source384.lastIndexOf(" "));
+      handleSelect({
+        ...item,
+        image: `${window.location.origin || ""}${nextImageSrc}`,
+      });
+    }
+  };
+
   return items ? (
     <div className="w-full h-full grid grid-cols-3 sm:grid-cols-4 md:grid-cols-5 lg:grid-cols-7 gap-4 justify-center items-center mt-12 mb-6 max-w-7xl">
       {items.map((item) => {
         const { tokenId, image } = item;
-        const isSelected = Boolean(selected.includes(item));
+        const isSelected = !!selected.find((i) => i.tokenId === tokenId);
         return (
           <div
             key={tokenId}
@@ -42,8 +72,8 @@ export const Grid: React.FC<GridProps> = ({
             />
             <div
               className="absolute w-full h-full flex justify-center items-center transition-opacity ease-out opacity-0 hover:opacity-100 hover:bg-slate-900/75"
-              onClick={() => {
-                isSelected ? handleRemove(item) : handleSelect(item);
+              onClick={(event) => {
+                handleClick(event.currentTarget, item, isSelected);
               }}
             >
               {isSelected ? (

--- a/components/NFTSelector/index.tsx
+++ b/components/NFTSelector/index.tsx
@@ -32,6 +32,7 @@ const Item: React.FC<{
             <Image
               fill
               priority
+              unoptimized // We are using the already optimised, pre-generated 384w of the image here
               src={item.image}
               alt={item.tokenId}
               className="transition-transform duration-175 ease-out hover:scale-105"
@@ -91,7 +92,9 @@ const NFTSelector = ({ address }: { address: string }) => {
   };
 
   const handleRemove = (oldItem: ItemType) => {
-    saveNFTs(config.selectedNFTs.filter((item) => item !== oldItem));
+    saveNFTs(
+      config.selectedNFTs.filter((item) => item.tokenId !== oldItem.tokenId)
+    );
   };
 
   const handleSubmit = async () => {

--- a/components/NFTSelector/index.tsx
+++ b/components/NFTSelector/index.tsx
@@ -10,7 +10,7 @@ import { BannerModal } from "./BannerModal";
 import { Grid } from "./Grid";
 import { SaveSnackbar } from "./SaveSnackbar";
 import { SelectCollection } from "./SelectCollection";
-import type { Item as ItemType } from "./types";
+import type { Item as ItemType, ItemWithNextImage } from "./types";
 
 const Item: React.FC<{
   children?: React.ReactNode;
@@ -32,7 +32,6 @@ const Item: React.FC<{
             <Image
               fill
               priority
-              unoptimized // We are using the already optimised, pre-generated 384w of the image here
               src={item.image}
               alt={item.tokenId}
               className="transition-transform duration-175 ease-out hover:scale-105"
@@ -81,7 +80,7 @@ const NFTSelector = ({ address }: { address: string }) => {
     errorFetchingCollections,
   } = useContext(BannerContext);
 
-  const handleSelect = (newItem: ItemType) => {
+  const handleSelect = (newItem: ItemWithNextImage) => {
     // If max 3 already selected, replace last with new selection
     if (config.selectedNFTs.length === 3) {
       saveNFTs([...config.selectedNFTs.slice(0, 2), newItem]);
@@ -91,7 +90,7 @@ const NFTSelector = ({ address }: { address: string }) => {
     saveNFTs([...config.selectedNFTs, newItem]);
   };
 
-  const handleRemove = (oldItem: ItemType) => {
+  const handleRemove = (oldItem: ItemWithNextImage) => {
     saveNFTs(
       config.selectedNFTs.filter((item) => item.tokenId !== oldItem.tokenId)
     );

--- a/components/NFTSelector/types.ts
+++ b/components/NFTSelector/types.ts
@@ -18,6 +18,10 @@ export interface Item {
   image: string;
 }
 
+export interface ItemWithNextImage extends Item {
+  nextURL?: string;
+}
+
 export interface Collection {
   name: string;
   items: Item[];
@@ -25,9 +29,9 @@ export interface Collection {
 
 export interface GridProps {
   items: Item[];
-  handleRemove(oldItem: Item): void;
-  handleSelect(newItem: Item): void;
-  selected: Item[];
+  handleRemove(oldItem: ItemWithNextImage): void;
+  handleSelect(newItem: ItemWithNextImage): void;
+  selected: ItemWithNextImage[];
   collectionName: string;
 }
 

--- a/context/BannerContext.tsx
+++ b/context/BannerContext.tsx
@@ -5,6 +5,7 @@ import type {
   Collection,
   DataResponse,
   Item,
+  ItemWithNextImage,
 } from "../components/NFTSelector/types";
 import { useAuthContext } from "../hooks/useAuthContext";
 
@@ -17,14 +18,14 @@ export type BannerContextType = {
   saveTwitterUsername: (username: string) => void;
   saveBannerStyle: (style: string) => void;
   saveBannerType: (type: BannerType) => void;
-  saveNFTs: (nfts: Item[]) => void;
+  saveNFTs: (nfts: ItemWithNextImage[]) => void;
 };
 
 export interface Config {
   manualWalletAddress: string;
   twitterUsername: string;
   style: BannerStyle;
-  selectedNFTs: Item[];
+  selectedNFTs: ItemWithNextImage[];
   type: BannerType;
 }
 

--- a/pages/create/theme.tsx
+++ b/pages/create/theme.tsx
@@ -131,6 +131,7 @@ const ThemePage: NextPage = () => {
             </button>
             <button
               className="block w-full min-w-[100px] py-2 rounded bg-indigo-600 text-md font-medium  text-white transition duration-150 ease-in-out hover:bg-indigo-500 disabled:bg-slate-500 disabled:cursor-not-allowed"
+              disabled={!config.style}
               onClick={() => {
                 push("/create/collection");
               }}

--- a/utils/banners/general/default.ts
+++ b/utils/banners/general/default.ts
@@ -15,28 +15,17 @@ export const buildDefaultImage = async (config: Config) => {
   const baseImageBuffer = fs.readFileSync(baseImagePath);
   const baseImage = sharp(baseImageBuffer);
 
-  const image1 = await axios.get(config.selectedNFTs[0].image, {
-    responseType: "arraybuffer",
-  });
-  const image2 = await axios.get(config.selectedNFTs[1].image, {
-    responseType: "arraybuffer",
-  });
-  const image3 = await axios.get(config.selectedNFTs[2].image, {
-    responseType: "arraybuffer",
-  });
+  const [image1, image2, image3] = await Promise.all([
+    axios.get(config.selectedNFTs[0].image, { responseType: "arraybuffer" }),
+    axios.get(config.selectedNFTs[1].image, { responseType: "arraybuffer" }),
+    axios.get(config.selectedNFTs[2].image, { responseType: "arraybuffer" }),
+  ]);
 
-  const imageBuffer1 = await sharp(image1.data)
-    .png()
-    .resize(274, 274, RESIZE_OPTIONS)
-    .toBuffer();
-  const imageBuffer2 = await sharp(image2.data)
-    .png()
-    .resize(274, 274, RESIZE_OPTIONS)
-    .toBuffer();
-  const imageBuffer3 = await sharp(image3.data)
-    .png()
-    .resize(274, 274, RESIZE_OPTIONS)
-    .toBuffer();
+  const [imageBuffer1, imageBuffer2, imageBuffer3] = await Promise.all([
+    sharp(image1.data).png().resize(274, 274, RESIZE_OPTIONS).toBuffer(),
+    sharp(image2.data).png().resize(274, 274, RESIZE_OPTIONS).toBuffer(),
+    sharp(image3.data).png().resize(274, 274, RESIZE_OPTIONS).toBuffer(),
+  ]);
 
   const compositeOptions: OverlayOptions[] = [
     { input: imageBuffer1, left: 464, top: 109 },

--- a/utils/banners/general/default.ts
+++ b/utils/banners/general/default.ts
@@ -15,11 +15,13 @@ export const buildDefaultImage = async (config: Config) => {
   const baseImageBuffer = fs.readFileSync(baseImagePath);
   const baseImage = sharp(baseImageBuffer);
 
-  const [image1, image2, image3] = await Promise.all([
-    axios.get(config.selectedNFTs[0].image, { responseType: "arraybuffer" }),
-    axios.get(config.selectedNFTs[1].image, { responseType: "arraybuffer" }),
-    axios.get(config.selectedNFTs[2].image, { responseType: "arraybuffer" }),
-  ]);
+  const [image1, image2, image3] = await Promise.all(
+    config.selectedNFTs.map((item) =>
+      axios.get(item.nextURL, {
+        responseType: "arraybuffer",
+      })
+    )
+  );
 
   const [imageBuffer1, imageBuffer2, imageBuffer3] = await Promise.all([
     sharp(image1.data).png().resize(274, 274, RESIZE_OPTIONS).toBuffer(),

--- a/utils/banners/general/posters.ts
+++ b/utils/banners/general/posters.ts
@@ -22,11 +22,13 @@ export const buildGeneralPostersImage = async (config: Config) => {
   );
   const overlayImageBuffer = fs.readFileSync(overlayImagePath);
 
-  const [image1, image2, image3] = await Promise.all([
-    axios.get(config.selectedNFTs[0].image, { responseType: "arraybuffer" }),
-    axios.get(config.selectedNFTs[1].image, { responseType: "arraybuffer" }),
-    axios.get(config.selectedNFTs[2].image, { responseType: "arraybuffer" }),
-  ]);
+  const [image1, image2, image3] = await Promise.all(
+    config.selectedNFTs.map((item) =>
+      axios.get(item.nextURL, {
+        responseType: "arraybuffer",
+      })
+    )
+  );
 
   const [imageBuffer1, imageBuffer2, imageBuffer3] = await Promise.all([
     await sharp(image1.data)

--- a/utils/banners/general/posters.ts
+++ b/utils/banners/general/posters.ts
@@ -22,31 +22,29 @@ export const buildGeneralPostersImage = async (config: Config) => {
   );
   const overlayImageBuffer = fs.readFileSync(overlayImagePath);
 
-  const image1 = await axios.get(config.selectedNFTs[0].image, {
-    responseType: "arraybuffer",
-  });
-  const image2 = await axios.get(config.selectedNFTs[1].image, {
-    responseType: "arraybuffer",
-  });
-  const image3 = await axios.get(config.selectedNFTs[2].image, {
-    responseType: "arraybuffer",
-  });
+  const [image1, image2, image3] = await Promise.all([
+    axios.get(config.selectedNFTs[0].image, { responseType: "arraybuffer" }),
+    axios.get(config.selectedNFTs[1].image, { responseType: "arraybuffer" }),
+    axios.get(config.selectedNFTs[2].image, { responseType: "arraybuffer" }),
+  ]);
 
-  const imageBuffer1 = await sharp(image1.data)
-    .png()
-    .resize(317, 317, RESIZE_OPTIONS)
-    .rotate(5.3, { background: { r: 0, g: 0, b: 0, alpha: 0 } })
-    .toBuffer();
-  const imageBuffer2 = await sharp(image2.data)
-    .png()
-    .resize(342, 342, RESIZE_OPTIONS)
-    .rotate(-1.5, { background: { r: 0, g: 0, b: 0, alpha: 0 } })
-    .toBuffer();
-  const imageBuffer3 = await sharp(image3.data)
-    .png()
-    .resize(330, 330, RESIZE_OPTIONS)
-    .rotate(4, { background: { r: 0, g: 0, b: 0, alpha: 0 } })
-    .toBuffer();
+  const [imageBuffer1, imageBuffer2, imageBuffer3] = await Promise.all([
+    await sharp(image1.data)
+      .png()
+      .resize(317, 317, RESIZE_OPTIONS)
+      .rotate(5.3, { background: { r: 0, g: 0, b: 0, alpha: 0 } })
+      .toBuffer(),
+    await sharp(image2.data)
+      .png()
+      .resize(342, 342, RESIZE_OPTIONS)
+      .rotate(-1.5, { background: { r: 0, g: 0, b: 0, alpha: 0 } })
+      .toBuffer(),
+    await sharp(image3.data)
+      .png()
+      .resize(330, 330, RESIZE_OPTIONS)
+      .rotate(4, { background: { r: 0, g: 0, b: 0, alpha: 0 } })
+      .toBuffer(),
+  ]);
 
   const compositeOptions: OverlayOptions[] = [
     { input: imageBuffer1, left: 47, top: 144 },

--- a/utils/banners/twitter/apeclub.ts
+++ b/utils/banners/twitter/apeclub.ts
@@ -15,11 +15,13 @@ export const buildApeclubImage = async (config: Config) => {
   const baseImageBuffer = fs.readFileSync(baseImagePath);
   const baseImage = sharp(baseImageBuffer);
 
-  const [image1, image2, image3] = await Promise.all([
-    axios.get(config.selectedNFTs[0].image, { responseType: "arraybuffer" }),
-    axios.get(config.selectedNFTs[1].image, { responseType: "arraybuffer" }),
-    axios.get(config.selectedNFTs[2].image, { responseType: "arraybuffer" }),
-  ]);
+  const [image1, image2, image3] = await Promise.all(
+    config.selectedNFTs.map((item) =>
+      axios.get(item.nextURL, {
+        responseType: "arraybuffer",
+      })
+    )
+  );
 
   const [imageBuffer1, imageBuffer2, imageBuffer3] = await Promise.all([
     sharp(image1.data).png().resize(274, 274, RESIZE_OPTIONS).toBuffer(),

--- a/utils/banners/twitter/apeclub.ts
+++ b/utils/banners/twitter/apeclub.ts
@@ -15,28 +15,17 @@ export const buildApeclubImage = async (config: Config) => {
   const baseImageBuffer = fs.readFileSync(baseImagePath);
   const baseImage = sharp(baseImageBuffer);
 
-  const image1 = await axios.get(config.selectedNFTs[0].image, {
-    responseType: "arraybuffer",
-  });
-  const image2 = await axios.get(config.selectedNFTs[1].image, {
-    responseType: "arraybuffer",
-  });
-  const image3 = await axios.get(config.selectedNFTs[2].image, {
-    responseType: "arraybuffer",
-  });
+  const [image1, image2, image3] = await Promise.all([
+    axios.get(config.selectedNFTs[0].image, { responseType: "arraybuffer" }),
+    axios.get(config.selectedNFTs[1].image, { responseType: "arraybuffer" }),
+    axios.get(config.selectedNFTs[2].image, { responseType: "arraybuffer" }),
+  ]);
 
-  const imageBuffer1 = await sharp(image1.data)
-    .png()
-    .resize(274, 274, RESIZE_OPTIONS)
-    .toBuffer();
-  const imageBuffer2 = await sharp(image2.data)
-    .png()
-    .resize(274, 274, RESIZE_OPTIONS)
-    .toBuffer();
-  const imageBuffer3 = await sharp(image3.data)
-    .png()
-    .resize(274, 274, RESIZE_OPTIONS)
-    .toBuffer();
+  const [imageBuffer1, imageBuffer2, imageBuffer3] = await Promise.all([
+    sharp(image1.data).png().resize(274, 274, RESIZE_OPTIONS).toBuffer(),
+    sharp(image2.data).png().resize(274, 274, RESIZE_OPTIONS).toBuffer(),
+    sharp(image3.data).png().resize(274, 274, RESIZE_OPTIONS).toBuffer(),
+  ]);
 
   const compositeOptions: OverlayOptions[] = [
     { input: imageBuffer1, left: 464, top: 109 },

--- a/utils/banners/twitter/coinflip.ts
+++ b/utils/banners/twitter/coinflip.ts
@@ -15,11 +15,13 @@ export const buildCoinflipImage = async (config: Config) => {
   const baseImageBuffer = fs.readFileSync(baseImagePath);
   const baseImage = sharp(baseImageBuffer);
 
-  const [image1, image2, image3] = await Promise.all([
-    axios.get(config.selectedNFTs[0].image, { responseType: "arraybuffer" }),
-    axios.get(config.selectedNFTs[1].image, { responseType: "arraybuffer" }),
-    axios.get(config.selectedNFTs[2].image, { responseType: "arraybuffer" }),
-  ]);
+  const [image1, image2, image3] = await Promise.all(
+    config.selectedNFTs.map((item) =>
+      axios.get(item.nextURL, {
+        responseType: "arraybuffer",
+      })
+    )
+  );
 
   const [imageBuffer1, imageBuffer2, imageBuffer3] = await Promise.all([
     sharp(image1.data).png().resize(262, 262, RESIZE_OPTIONS).toBuffer(),

--- a/utils/banners/twitter/coinflip.ts
+++ b/utils/banners/twitter/coinflip.ts
@@ -15,28 +15,17 @@ export const buildCoinflipImage = async (config: Config) => {
   const baseImageBuffer = fs.readFileSync(baseImagePath);
   const baseImage = sharp(baseImageBuffer);
 
-  const image1 = await axios.get(config.selectedNFTs[0].image, {
-    responseType: "arraybuffer",
-  });
-  const image2 = await axios.get(config.selectedNFTs[1].image, {
-    responseType: "arraybuffer",
-  });
-  const image3 = await axios.get(config.selectedNFTs[2].image, {
-    responseType: "arraybuffer",
-  });
+  const [image1, image2, image3] = await Promise.all([
+    axios.get(config.selectedNFTs[0].image, { responseType: "arraybuffer" }),
+    axios.get(config.selectedNFTs[1].image, { responseType: "arraybuffer" }),
+    axios.get(config.selectedNFTs[2].image, { responseType: "arraybuffer" }),
+  ]);
 
-  const imageBuffer1 = await sharp(image1.data)
-    .png()
-    .resize(262, 262, RESIZE_OPTIONS)
-    .toBuffer();
-  const imageBuffer2 = await sharp(image2.data)
-    .png()
-    .resize(262, 262, RESIZE_OPTIONS)
-    .toBuffer();
-  const imageBuffer3 = await sharp(image3.data)
-    .png()
-    .resize(262, 262, RESIZE_OPTIONS)
-    .toBuffer();
+  const [imageBuffer1, imageBuffer2, imageBuffer3] = await Promise.all([
+    sharp(image1.data).png().resize(262, 262, RESIZE_OPTIONS).toBuffer(),
+    sharp(image2.data).png().resize(262, 262, RESIZE_OPTIONS).toBuffer(),
+    sharp(image3.data).png().resize(262, 262, RESIZE_OPTIONS).toBuffer(),
+  ]);
 
   const compositeOptions: OverlayOptions[] = [
     { input: imageBuffer1, left: 485, top: 206 },

--- a/utils/banners/twitter/fantasy.ts
+++ b/utils/banners/twitter/fantasy.ts
@@ -1,10 +1,10 @@
+import axios from "axios";
 import fs from "fs";
 import path from "path";
-import axios from "axios";
 import sharp, { OverlayOptions } from "sharp";
-import { RESIZE_OPTIONS } from "../constants";
 
 import type { Config } from "../../../context/BannerContext";
+import { RESIZE_OPTIONS } from "../constants";
 
 export const buildFantasyImage = async (config: Config) => {
   const baseImagePath = path.join(
@@ -15,31 +15,29 @@ export const buildFantasyImage = async (config: Config) => {
   const baseImageBuffer = fs.readFileSync(baseImagePath);
   const baseImage = sharp(baseImageBuffer);
 
-  const image1 = await axios.get(config.selectedNFTs[0].image, {
-    responseType: "arraybuffer",
-  });
-  const image2 = await axios.get(config.selectedNFTs[1].image, {
-    responseType: "arraybuffer",
-  });
-  const image3 = await axios.get(config.selectedNFTs[2].image, {
-    responseType: "arraybuffer",
-  });
+  const [image1, image2, image3] = await Promise.all([
+    axios.get(config.selectedNFTs[0].image, { responseType: "arraybuffer" }),
+    axios.get(config.selectedNFTs[1].image, { responseType: "arraybuffer" }),
+    axios.get(config.selectedNFTs[2].image, { responseType: "arraybuffer" }),
+  ]);
 
-  const imageBuffer1 = await sharp(image1.data)
-    .png()
-    .resize(252, 252, RESIZE_OPTIONS)
-    .rotate(-2.8, { background: { r: 0, g: 0, b: 0, alpha: 0 } })
-    .toBuffer();
-  const imageBuffer2 = await sharp(image2.data)
-    .png()
-    .resize(287, 287, RESIZE_OPTIONS)
-    .rotate(1.2, { background: { r: 0, g: 0, b: 0, alpha: 0 } })
-    .toBuffer();
-  const imageBuffer3 = await sharp(image3.data)
-    .png()
-    .resize(236, 236, RESIZE_OPTIONS)
-    .rotate(-2, { background: { r: 0, g: 0, b: 0, alpha: 0 } })
-    .toBuffer();
+  const [imageBuffer1, imageBuffer2, imageBuffer3] = await Promise.all([
+    await sharp(image1.data)
+      .png()
+      .resize(252, 252, RESIZE_OPTIONS)
+      .rotate(-2.8, { background: { r: 0, g: 0, b: 0, alpha: 0 } })
+      .toBuffer(),
+    await sharp(image2.data)
+      .png()
+      .resize(287, 287, RESIZE_OPTIONS)
+      .rotate(1.2, { background: { r: 0, g: 0, b: 0, alpha: 0 } })
+      .toBuffer(),
+    await sharp(image3.data)
+      .png()
+      .resize(236, 236, RESIZE_OPTIONS)
+      .rotate(-2, { background: { r: 0, g: 0, b: 0, alpha: 0 } })
+      .toBuffer(),
+  ]);
 
   const compositeOptions: OverlayOptions[] = [
     { input: imageBuffer1, left: 477, top: 121 },

--- a/utils/banners/twitter/fantasy.ts
+++ b/utils/banners/twitter/fantasy.ts
@@ -15,11 +15,13 @@ export const buildFantasyImage = async (config: Config) => {
   const baseImageBuffer = fs.readFileSync(baseImagePath);
   const baseImage = sharp(baseImageBuffer);
 
-  const [image1, image2, image3] = await Promise.all([
-    axios.get(config.selectedNFTs[0].image, { responseType: "arraybuffer" }),
-    axios.get(config.selectedNFTs[1].image, { responseType: "arraybuffer" }),
-    axios.get(config.selectedNFTs[2].image, { responseType: "arraybuffer" }),
-  ]);
+  const [image1, image2, image3] = await Promise.all(
+    config.selectedNFTs.map((item) =>
+      axios.get(item.nextURL, {
+        responseType: "arraybuffer",
+      })
+    )
+  );
 
   const [imageBuffer1, imageBuffer2, imageBuffer3] = await Promise.all([
     await sharp(image1.data)

--- a/utils/banners/twitter/gallery.ts
+++ b/utils/banners/twitter/gallery.ts
@@ -22,11 +22,13 @@ export const buildGalleryImage = async (config: Config) => {
   );
   const overlayImageBuffer = fs.readFileSync(overlayImagePath);
 
-  const [image1, image2, image3] = await Promise.all([
-    axios.get(config.selectedNFTs[0].image, { responseType: "arraybuffer" }),
-    axios.get(config.selectedNFTs[1].image, { responseType: "arraybuffer" }),
-    axios.get(config.selectedNFTs[2].image, { responseType: "arraybuffer" }),
-  ]);
+  const [image1, image2, image3] = await Promise.all(
+    config.selectedNFTs.map((item) =>
+      axios.get(item.nextURL, {
+        responseType: "arraybuffer",
+      })
+    )
+  );
 
   const [imageBuffer1, imageBuffer2, imageBuffer3] = await Promise.all([
     sharp(image1.data).png().resize(244, 244, RESIZE_OPTIONS).toBuffer(),

--- a/utils/banners/twitter/gallery.ts
+++ b/utils/banners/twitter/gallery.ts
@@ -22,28 +22,17 @@ export const buildGalleryImage = async (config: Config) => {
   );
   const overlayImageBuffer = fs.readFileSync(overlayImagePath);
 
-  const image1 = await axios.get(config.selectedNFTs[0].image, {
-    responseType: "arraybuffer",
-  });
-  const image2 = await axios.get(config.selectedNFTs[1].image, {
-    responseType: "arraybuffer",
-  });
-  const image3 = await axios.get(config.selectedNFTs[2].image, {
-    responseType: "arraybuffer",
-  });
+  const [image1, image2, image3] = await Promise.all([
+    axios.get(config.selectedNFTs[0].image, { responseType: "arraybuffer" }),
+    axios.get(config.selectedNFTs[1].image, { responseType: "arraybuffer" }),
+    axios.get(config.selectedNFTs[2].image, { responseType: "arraybuffer" }),
+  ]);
 
-  const imageBuffer1 = await sharp(image1.data)
-    .png()
-    .resize(244, 244, RESIZE_OPTIONS)
-    .toBuffer();
-  const imageBuffer2 = await sharp(image2.data)
-    .png()
-    .resize(244, 244, RESIZE_OPTIONS)
-    .toBuffer();
-  const imageBuffer3 = await sharp(image3.data)
-    .png()
-    .resize(244, 244, RESIZE_OPTIONS)
-    .toBuffer();
+  const [imageBuffer1, imageBuffer2, imageBuffer3] = await Promise.all([
+    sharp(image1.data).png().resize(244, 244, RESIZE_OPTIONS).toBuffer(),
+    sharp(image2.data).png().resize(244, 244, RESIZE_OPTIONS).toBuffer(),
+    sharp(image3.data).png().resize(244, 244, RESIZE_OPTIONS).toBuffer(),
+  ]);
 
   const compositeOptions: OverlayOptions[] = [
     { input: imageBuffer1, left: 228, top: 86 },

--- a/utils/banners/twitter/gelotto.ts
+++ b/utils/banners/twitter/gelotto.ts
@@ -15,11 +15,13 @@ export const buildGelottoImage = async (config: Config) => {
   const baseImageBuffer = fs.readFileSync(baseImagePath);
   const baseImage = sharp(baseImageBuffer);
 
-  const [image1, image2, image3] = await Promise.all([
-    axios.get(config.selectedNFTs[0].image, { responseType: "arraybuffer" }),
-    axios.get(config.selectedNFTs[1].image, { responseType: "arraybuffer" }),
-    axios.get(config.selectedNFTs[2].image, { responseType: "arraybuffer" }),
-  ]);
+  const [image1, image2, image3] = await Promise.all(
+    config.selectedNFTs.map((item) =>
+      axios.get(item.nextURL, {
+        responseType: "arraybuffer",
+      })
+    )
+  );
 
   const [imageBuffer1, imageBuffer2, imageBuffer3] = await Promise.all([
     sharp(image1.data).png().resize(280, 280, RESIZE_OPTIONS).toBuffer(),

--- a/utils/banners/twitter/gelotto.ts
+++ b/utils/banners/twitter/gelotto.ts
@@ -15,28 +15,17 @@ export const buildGelottoImage = async (config: Config) => {
   const baseImageBuffer = fs.readFileSync(baseImagePath);
   const baseImage = sharp(baseImageBuffer);
 
-  const image1 = await axios.get(config.selectedNFTs[0].image, {
-    responseType: "arraybuffer",
-  });
-  const image2 = await axios.get(config.selectedNFTs[1].image, {
-    responseType: "arraybuffer",
-  });
-  const image3 = await axios.get(config.selectedNFTs[2].image, {
-    responseType: "arraybuffer",
-  });
+  const [image1, image2, image3] = await Promise.all([
+    axios.get(config.selectedNFTs[0].image, { responseType: "arraybuffer" }),
+    axios.get(config.selectedNFTs[1].image, { responseType: "arraybuffer" }),
+    axios.get(config.selectedNFTs[2].image, { responseType: "arraybuffer" }),
+  ]);
 
-  const imageBuffer1 = await sharp(image1.data)
-    .png()
-    .resize(280, 280, RESIZE_OPTIONS)
-    .toBuffer();
-  const imageBuffer2 = await sharp(image2.data)
-    .png()
-    .resize(280, 280, RESIZE_OPTIONS)
-    .toBuffer();
-  const imageBuffer3 = await sharp(image3.data)
-    .png()
-    .resize(280, 280, RESIZE_OPTIONS)
-    .toBuffer();
+  const [imageBuffer1, imageBuffer2, imageBuffer3] = await Promise.all([
+    sharp(image1.data).png().resize(280, 280, RESIZE_OPTIONS).toBuffer(),
+    sharp(image2.data).png().resize(280, 280, RESIZE_OPTIONS).toBuffer(),
+    sharp(image3.data).png().resize(280, 280, RESIZE_OPTIONS).toBuffer(),
+  ]);
 
   const compositeOptions: OverlayOptions[] = [
     { input: imageBuffer1, left: 502, top: 97 },

--- a/utils/banners/twitter/jungle.ts
+++ b/utils/banners/twitter/jungle.ts
@@ -22,31 +22,29 @@ export const buildJungleImage = async (config: Config) => {
   );
   const overlayImageBuffer = fs.readFileSync(overlayImagePath);
 
-  const image1 = await axios.get(config.selectedNFTs[0].image, {
-    responseType: "arraybuffer",
-  });
-  const image2 = await axios.get(config.selectedNFTs[1].image, {
-    responseType: "arraybuffer",
-  });
-  const image3 = await axios.get(config.selectedNFTs[2].image, {
-    responseType: "arraybuffer",
-  });
+  const [image1, image2, image3] = await Promise.all([
+    axios.get(config.selectedNFTs[0].image, { responseType: "arraybuffer" }),
+    axios.get(config.selectedNFTs[1].image, { responseType: "arraybuffer" }),
+    axios.get(config.selectedNFTs[2].image, { responseType: "arraybuffer" }),
+  ]);
 
-  const imageBuffer1 = await sharp(image1.data)
-    .png()
-    .resize(271, 271, RESIZE_OPTIONS)
-    .rotate(-2, { background: { r: 0, g: 0, b: 0, alpha: 0 } })
-    .toBuffer();
-  const imageBuffer2 = await sharp(image2.data)
-    .png()
-    .resize(305, 305, RESIZE_OPTIONS)
-    .rotate(2.3, { background: { r: 0, g: 0, b: 0, alpha: 0 } })
-    .toBuffer();
-  const imageBuffer3 = await sharp(image3.data)
-    .png()
-    .resize(245, 245, RESIZE_OPTIONS)
-    .rotate(0.8, { background: { r: 0, g: 0, b: 0, alpha: 0 } })
-    .toBuffer();
+  const [imageBuffer1, imageBuffer2, imageBuffer3] = await Promise.all([
+    await sharp(image1.data)
+      .png()
+      .resize(271, 271, RESIZE_OPTIONS)
+      .rotate(-2, { background: { r: 0, g: 0, b: 0, alpha: 0 } })
+      .toBuffer(),
+    await sharp(image2.data)
+      .png()
+      .resize(305, 305, RESIZE_OPTIONS)
+      .rotate(2.3, { background: { r: 0, g: 0, b: 0, alpha: 0 } })
+      .toBuffer(),
+    await sharp(image3.data)
+      .png()
+      .resize(245, 245, RESIZE_OPTIONS)
+      .rotate(0.8, { background: { r: 0, g: 0, b: 0, alpha: 0 } })
+      .toBuffer(),
+  ]);
 
   const compositeOptions: OverlayOptions[] = [
     { input: imageBuffer1, left: 470, top: 120 },

--- a/utils/banners/twitter/jungle.ts
+++ b/utils/banners/twitter/jungle.ts
@@ -22,11 +22,13 @@ export const buildJungleImage = async (config: Config) => {
   );
   const overlayImageBuffer = fs.readFileSync(overlayImagePath);
 
-  const [image1, image2, image3] = await Promise.all([
-    axios.get(config.selectedNFTs[0].image, { responseType: "arraybuffer" }),
-    axios.get(config.selectedNFTs[1].image, { responseType: "arraybuffer" }),
-    axios.get(config.selectedNFTs[2].image, { responseType: "arraybuffer" }),
-  ]);
+  const [image1, image2, image3] = await Promise.all(
+    config.selectedNFTs.map((item) =>
+      axios.get(item.nextURL, {
+        responseType: "arraybuffer",
+      })
+    )
+  );
 
   const [imageBuffer1, imageBuffer2, imageBuffer3] = await Promise.all([
     await sharp(image1.data)

--- a/utils/banners/twitter/pixelwizards.ts
+++ b/utils/banners/twitter/pixelwizards.ts
@@ -15,11 +15,13 @@ export const buildPixelWizardsImage = async (config: Config) => {
   const baseImageBuffer = fs.readFileSync(baseImagePath);
   const baseImage = sharp(baseImageBuffer);
 
-  const [image1, image2, image3] = await Promise.all([
-    axios.get(config.selectedNFTs[0].image, { responseType: "arraybuffer" }),
-    axios.get(config.selectedNFTs[1].image, { responseType: "arraybuffer" }),
-    axios.get(config.selectedNFTs[2].image, { responseType: "arraybuffer" }),
-  ]);
+  const [image1, image2, image3] = await Promise.all(
+    config.selectedNFTs.map((item) =>
+      axios.get(item.nextURL, {
+        responseType: "arraybuffer",
+      })
+    )
+  );
 
   const [imageBuffer1, imageBuffer2, imageBuffer3] = await Promise.all([
     await sharp(image1.data)

--- a/utils/banners/twitter/pixelwizards.ts
+++ b/utils/banners/twitter/pixelwizards.ts
@@ -15,31 +15,29 @@ export const buildPixelWizardsImage = async (config: Config) => {
   const baseImageBuffer = fs.readFileSync(baseImagePath);
   const baseImage = sharp(baseImageBuffer);
 
-  const image1 = await axios.get(config.selectedNFTs[0].image, {
-    responseType: "arraybuffer",
-  });
-  const image2 = await axios.get(config.selectedNFTs[1].image, {
-    responseType: "arraybuffer",
-  });
-  const image3 = await axios.get(config.selectedNFTs[2].image, {
-    responseType: "arraybuffer",
-  });
+  const [image1, image2, image3] = await Promise.all([
+    axios.get(config.selectedNFTs[0].image, { responseType: "arraybuffer" }),
+    axios.get(config.selectedNFTs[1].image, { responseType: "arraybuffer" }),
+    axios.get(config.selectedNFTs[2].image, { responseType: "arraybuffer" }),
+  ]);
 
-  const imageBuffer1 = await sharp(image1.data)
-    .png()
-    .resize(208, 208, RESIZE_OPTIONS)
-    .rotate(2, { background: { r: 0, g: 0, b: 0, alpha: 0 } })
-    .toBuffer();
-  const imageBuffer2 = await sharp(image2.data)
-    .png()
-    .resize(208, 208, RESIZE_OPTIONS)
-    .rotate(-2, { background: { r: 0, g: 0, b: 0, alpha: 0 } })
-    .toBuffer();
-  const imageBuffer3 = await sharp(image3.data)
-    .png()
-    .resize(208, 208, RESIZE_OPTIONS)
-    .rotate(1.01, { background: { r: 0, g: 0, b: 0, alpha: 0 } })
-    .toBuffer();
+  const [imageBuffer1, imageBuffer2, imageBuffer3] = await Promise.all([
+    await sharp(image1.data)
+      .png()
+      .resize(208, 208, RESIZE_OPTIONS)
+      .rotate(2, { background: { r: 0, g: 0, b: 0, alpha: 0 } })
+      .toBuffer(),
+    await sharp(image2.data)
+      .png()
+      .resize(208, 208, RESIZE_OPTIONS)
+      .rotate(-2, { background: { r: 0, g: 0, b: 0, alpha: 0 } })
+      .toBuffer(),
+    await sharp(image3.data)
+      .png()
+      .resize(208, 208, RESIZE_OPTIONS)
+      .rotate(1.01, { background: { r: 0, g: 0, b: 0, alpha: 0 } })
+      .toBuffer(),
+  ]);
 
   const compositeOptions: OverlayOptions[] = [
     { input: imageBuffer1, left: 196, top: 107 },

--- a/utils/banners/twitter/posters.ts
+++ b/utils/banners/twitter/posters.ts
@@ -32,21 +32,23 @@ export const buildPostersImage = async (config: Config) => {
     responseType: "arraybuffer",
   });
 
-  const imageBuffer1 = await sharp(image1.data)
-    .png()
-    .resize(290, 290, RESIZE_OPTIONS)
-    .rotate(5.3, { background: { r: 0, g: 0, b: 0, alpha: 0 } })
-    .toBuffer();
-  const imageBuffer2 = await sharp(image2.data)
-    .png()
-    .resize(308, 308, RESIZE_OPTIONS)
-    .rotate(-1.5, { background: { r: 0, g: 0, b: 0, alpha: 0 } })
-    .toBuffer();
-  const imageBuffer3 = await sharp(image3.data)
-    .png()
-    .resize(302, 302, RESIZE_OPTIONS)
-    .rotate(4, { background: { r: 0, g: 0, b: 0, alpha: 0 } })
-    .toBuffer();
+  const [imageBuffer1, imageBuffer2, imageBuffer3] = await Promise.all([
+    await sharp(image1.data)
+      .png()
+      .resize(290, 290, RESIZE_OPTIONS)
+      .rotate(5.3, { background: { r: 0, g: 0, b: 0, alpha: 0 } })
+      .toBuffer(),
+    await sharp(image2.data)
+      .png()
+      .resize(308, 308, RESIZE_OPTIONS)
+      .rotate(-1.5, { background: { r: 0, g: 0, b: 0, alpha: 0 } })
+      .toBuffer(),
+    await sharp(image3.data)
+      .png()
+      .resize(302, 302, RESIZE_OPTIONS)
+      .rotate(4, { background: { r: 0, g: 0, b: 0, alpha: 0 } })
+      .toBuffer(),
+  ]);
 
   const compositeOptions: OverlayOptions[] = [
     { input: imageBuffer1, left: 329, top: 46 },

--- a/utils/banners/twitter/posters.ts
+++ b/utils/banners/twitter/posters.ts
@@ -22,15 +22,13 @@ export const buildPostersImage = async (config: Config) => {
   );
   const overlayImageBuffer = fs.readFileSync(overlayImagePath);
 
-  const image1 = await axios.get(config.selectedNFTs[0].image, {
-    responseType: "arraybuffer",
-  });
-  const image2 = await axios.get(config.selectedNFTs[1].image, {
-    responseType: "arraybuffer",
-  });
-  const image3 = await axios.get(config.selectedNFTs[2].image, {
-    responseType: "arraybuffer",
-  });
+  const [image1, image2, image3] = await Promise.all(
+    config.selectedNFTs.map((item) =>
+      axios.get(item.nextURL, {
+        responseType: "arraybuffer",
+      })
+    )
+  );
 
   const [imageBuffer1, imageBuffer2, imageBuffer3] = await Promise.all([
     await sharp(image1.data)

--- a/utils/banners/twitter/street.ts
+++ b/utils/banners/twitter/street.ts
@@ -15,46 +15,42 @@ export const buildStreetImage = async (config: Config) => {
   const baseImageBuffer = fs.readFileSync(baseImagePath);
   const baseImage = sharp(baseImageBuffer);
 
-  const image1 = await axios.get(config.selectedNFTs[0].image, {
-    responseType: "arraybuffer",
-  });
-  const image2 = await axios.get(config.selectedNFTs[1].image, {
-    responseType: "arraybuffer",
-  });
-  const image3 = await axios.get(config.selectedNFTs[2].image, {
-    responseType: "arraybuffer",
-  });
+  const [image1, image2, image3] = await Promise.all([
+    axios.get(config.selectedNFTs[0].image, { responseType: "arraybuffer" }),
+    axios.get(config.selectedNFTs[1].image, { responseType: "arraybuffer" }),
+    axios.get(config.selectedNFTs[2].image, { responseType: "arraybuffer" }),
+  ]);
 
-  const imageBuffer1 = await sharp(image1.data)
-    .png()
-    .resize(317, 317, RESIZE_OPTIONS)
-    .toBuffer();
-  const imageBuffer2 = await sharp(image2.data)
-    .png()
-    .resize(317, 317, RESIZE_OPTIONS)
-    .toBuffer();
-  const imageBuffer3 = await sharp(image3.data)
-    .png()
-    .resize(317, 317, RESIZE_OPTIONS)
-    .toBuffer();
-  const imageBufferReflection1 = await sharp(image1.data)
-    .png()
-    .resize(317, 317, RESIZE_OPTIONS)
-    .flip()
-    .blur(3)
-    .toBuffer();
-  const imageBufferReflection2 = await sharp(image2.data)
-    .png()
-    .resize(317, 317, RESIZE_OPTIONS)
-    .flip()
-    .blur(3)
-    .toBuffer();
-  const imageBufferReflection3 = await sharp(image3.data)
-    .png()
-    .resize(317, 317, RESIZE_OPTIONS)
-    .flip()
-    .blur(3)
-    .toBuffer();
+  const [
+    imageBuffer1,
+    imageBuffer2,
+    imageBuffer3,
+    imageBufferReflection1,
+    imageBufferReflection2,
+    imageBufferReflection3,
+  ] = await Promise.all([
+    await sharp(image1.data).png().resize(317, 317, RESIZE_OPTIONS).toBuffer(),
+    await sharp(image2.data).png().resize(317, 317, RESIZE_OPTIONS).toBuffer(),
+    await sharp(image3.data).png().resize(317, 317, RESIZE_OPTIONS).toBuffer(),
+    await sharp(image1.data)
+      .png()
+      .resize(317, 317, RESIZE_OPTIONS)
+      .flip()
+      .blur(3)
+      .toBuffer(),
+    await sharp(image2.data)
+      .png()
+      .resize(317, 317, RESIZE_OPTIONS)
+      .flip()
+      .blur(3)
+      .toBuffer(),
+    await sharp(image3.data)
+      .png()
+      .resize(317, 317, RESIZE_OPTIONS)
+      .flip()
+      .blur(3)
+      .toBuffer(),
+  ]);
 
   const compositeOptions: OverlayOptions[] = [
     { input: imageBuffer1, left: 404, top: 91 },

--- a/utils/banners/twitter/street.ts
+++ b/utils/banners/twitter/street.ts
@@ -15,11 +15,13 @@ export const buildStreetImage = async (config: Config) => {
   const baseImageBuffer = fs.readFileSync(baseImagePath);
   const baseImage = sharp(baseImageBuffer);
 
-  const [image1, image2, image3] = await Promise.all([
-    axios.get(config.selectedNFTs[0].image, { responseType: "arraybuffer" }),
-    axios.get(config.selectedNFTs[1].image, { responseType: "arraybuffer" }),
-    axios.get(config.selectedNFTs[2].image, { responseType: "arraybuffer" }),
-  ]);
+  const [image1, image2, image3] = await Promise.all(
+    config.selectedNFTs.map((item) =>
+      axios.get(item.nextURL, {
+        responseType: "arraybuffer",
+      })
+    )
+  );
 
   const [
     imageBuffer1,


### PR DESCRIPTION
So let's see if this actually works on a deployment...
- The free Vercel Hobby plan has execution time of 10s for Next.js API Routes. If we pass the URLs of the full res NFTs to the server, it takes too much time to download and resize combinations on NFTs of a certain size. So we are instead passing the Next.js generated 384w version of the NFT image, extracting that URLfrom the `srcset` of the related next/image component. This is so hacky it's fun 👍 :shipit: 

Other changes:
- Refactored async operations in my `sharp` logic into `Promise.all` groups.
- Small fix for disabling theme page "Next" button if no theme selected.