### PR TITLE
fix: unexpected behavior when switching between chains on the same wallet

### DIFF
--- a/components/AuthProvider.jsx
+++ b/components/AuthProvider.jsx
@@ -2,7 +2,7 @@ import { createContext, useEffect, useState } from "react";
 import { useManager } from "@cosmos-kit/react";
 
 import * as ApelloAPI from "../interface/apello";
-import waitFor from "../lib/waitFor";
+import useThread from "../hooks/useThread";
 
 const AUTH_CACHE_KEY = "apello/wallet";
 
@@ -11,13 +11,14 @@ export const AuthContext = createContext();
 export function AuthContextProvider({ children }) {
   const walletManager = useManager();
   const [auth, setAuth] = useState(null);
+  const thread = useThread();
 
   function connectWallet(chainName) {
     const walletRepo = walletManager.getWalletRepo(chainName);
     walletRepo.activate();
     walletRepo.connect();
 
-    return waitFor(() =>
+    return thread.run(() =>
       walletRepo.current?.isWalletConnected ? walletRepo.current : null,
     );
   }
@@ -27,8 +28,9 @@ export function AuthContextProvider({ children }) {
     if (!walletRepo.current) return;
 
     walletRepo.current.disconnect();
+    walletRepo.disconnect();
 
-    return waitFor(() => !walletRepo.current?.isWalletConnected);
+    return thread.run(() => !walletRepo.current?.isWalletConnected);
   }
 
   function view() {

--- a/hooks/useThread.ts
+++ b/hooks/useThread.ts
@@ -1,0 +1,45 @@
+import { useMemo } from "react";
+
+class Thread {
+  intervalID: number;
+  interval: number;
+
+  constructor(interval = 50) {
+    this.interval = interval;
+    this.intervalID = null;
+  }
+
+  run(f) {
+    if (this.intervalID) {
+      this.kill();
+    }
+
+    return new Promise((resolve, reject) => {
+      this.intervalID = window.setInterval(() => {
+        let result;
+
+        try {
+          result = f();
+          console.log(this.intervalID, result);
+        } catch (e) {
+          reject(e);
+        }
+
+        if (result) {
+          this.kill();
+          resolve(result);
+        }
+      }, 50);
+    });
+  }
+
+  kill() {
+    window.clearInterval(this.intervalID);
+    this.intervalID = null;
+  }
+}
+
+export default function useThread() {
+  const thread = useMemo(() => new Thread(), []);
+  return thread;
+}


### PR DESCRIPTION
The wallet repository was not fully disconnecting, meaning that reconnecting with a different chain sometimes skipped the wallet selection modal and immediately logged into the new chain.